### PR TITLE
Allow 'unspecified_source_income'/'quarterly' irregular payment type

### DIFF
--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -57,9 +57,11 @@ module CFEConstants
   # Irregular income categories and frequencies
   #
   ANNUAL_FREQUENCY = "annual".freeze
+  QUARTERLY_FREQUENCY = "quarterly".freeze
   STUDENT_LOAN = "student_loan".freeze
-  VALID_IRREGULAR_INCOME_FREQUENCIES = [ANNUAL_FREQUENCY].freeze
-  VALID_IRREGULAR_INCOME_TYPES = [STUDENT_LOAN].freeze
+  UNSPECIFIED_SOURCE_INCOME = "unspecified_source_income".freeze
+  VALID_IRREGULAR_INCOME_FREQUENCIES = [ANNUAL_FREQUENCY, QUARTERLY_FREQUENCY].freeze
+  VALID_IRREGULAR_INCOME_TYPES = [STUDENT_LOAN, UNSPECIFIED_SOURCE_INCOME].freeze
 
   # Date and bank holidays
   #

--- a/app/models/irregular_income_payment.rb
+++ b/app/models/irregular_income_payment.rb
@@ -4,4 +4,7 @@ class IrregularIncomePayment < ApplicationRecord
   validates :income_type, inclusion: { in: CFEConstants::VALID_IRREGULAR_INCOME_TYPES }
   validates :frequency, inclusion: { in: CFEConstants::VALID_IRREGULAR_INCOME_FREQUENCIES }
   validates :amount, numericality: { greater_than_or_equal_to: 0 }
+
+  scope :student_loan, -> { where(income_type: CFEConstants::STUDENT_LOAN) }
+  scope :unspecified, -> { where(income_type: CFEConstants::UNSPECIFIED_SOURCE_INCOME) }
 end

--- a/app/services/collators/childcare_collator.rb
+++ b/app/services/collators/childcare_collator.rb
@@ -30,7 +30,7 @@ module Collators
     end
 
     def applicant_has_student_loan?
-      return true if irregular_income_payments&.present?
+      return true if irregular_income_payments&.student_loan&.present?
 
       false
     end

--- a/app/services/decorators/v5/gross_income_decorator.rb
+++ b/app/services/decorators/v5/gross_income_decorator.rb
@@ -62,6 +62,7 @@ module Decorators
           monthly_equivalents:
             {
               student_loan: summary.monthly_student_loan.to_f,
+              unspecified_source_income: summary.monthly_unspecified_source_income.to_f,
             },
         }
       end

--- a/app/services/decorators/v5/gross_income_summary_decorator.rb
+++ b/app/services/decorators/v5/gross_income_summary_decorator.rb
@@ -33,6 +33,7 @@ module Decorators
           irregular_income: {
             monthly_equivalents: {
               student_loan: record.monthly_student_loan,
+              unspecified_source_income: record.unspecified_source_income,
             },
           },
           state_benefits: {

--- a/db/migrate/20221014131213_add_unspecified_source_income_to_gross_income_summaries.rb
+++ b/db/migrate/20221014131213_add_unspecified_source_income_to_gross_income_summaries.rb
@@ -1,0 +1,8 @@
+class AddUnspecifiedSourceIncomeToGrossIncomeSummaries < ActiveRecord::Migration[7.0]
+  def change
+    change_table :gross_income_summaries, bulk: true do |t|
+      t.decimal "unspecified_source_income", default: "0.0"
+      t.decimal "monthly_unspecified_source_income"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_15_153334) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_14_131213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -226,6 +226,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_153334) do
     t.decimal "pension_cash", default: "0.0"
     t.decimal "gross_employment_income", default: "0.0", null: false
     t.decimal "benefits_in_kind", default: "0.0", null: false
+    t.decimal "unspecified_source_income", default: "0.0"
+    t.decimal "monthly_unspecified_source_income"
     t.index ["assessment_id"], name: "index_gross_income_summaries_on_assessment_id"
   end
 

--- a/public/schemas/irregular_incomes.json.erb
+++ b/public/schemas/irregular_incomes.json.erb
@@ -5,21 +5,23 @@
   "type": "object",
   "properties": {
     "payments": {
-      "description": "Describes irregular payments received by applicant (currently annual student loan is the only irregular income allowed)",
+      "description": "Describes irregular payments received by applicant",
       "type": "array",
       "minItems": 0,
-      "maxItems": 1,
+      "maxItems": 2,
       "items": {
         "type": "object",
         "properties": {
           "income_type": {
             "enum": [
-              "student_loan"
+              "student_loan",
+              "unspecified_source_income"
             ]
           },
           "frequency": {
             "enum": [
-              "annual"
+              "annual",
+              "quarterly"
             ]
           },
           "amount": {

--- a/spec/integration/policy_disregards_spec.rb
+++ b/spec/integration/policy_disregards_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Eligible Full Assessment with policy disregard remarks" do
   end
 
   def post_irregular_income(assessment_id)
-    post assessment_irregular_incomes_path(assessment_id), params: student_loan_params, headers: headers
+    post assessment_irregular_incomes_path(assessment_id), params: irregular_income_params, headers: headers
     output_response(:post, :irregular_income)
   end
 
@@ -254,11 +254,14 @@ RSpec.describe "Eligible Full Assessment with policy disregard remarks" do
                     "client_id" => "TX-state-benefits-3" }] }] }.to_json
   end
 
-  def student_loan_params
+  def irregular_income_params
     { "payments" =>
           [{ "income_type" => "student_loan",
              "frequency" => "annual",
-             "amount" => 100.0 }] }.to_json
+             "amount" => 100.0 },
+           { "income_type" => "unspecified_source_income",
+             "frequency" => "quarterly",
+             "amount" => 303.0 }] }.to_json
   end
 
   def explicit_remarks_params

--- a/spec/integration/v5_full_assessment_spec.rb
+++ b/spec/integration/v5_full_assessment_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "Full V5 passported spec", :vcr do
   end
 
   def post_irregular_income(assessment_id)
-    post assessment_irregular_incomes_path(assessment_id), params: student_loan_params, headers: headers
+    post assessment_irregular_incomes_path(assessment_id), params: irregular_income_params, headers: headers
     output_response(:post, :irregular_income)
   end
 
@@ -432,11 +432,14 @@ RSpec.describe "Full V5 passported spec", :vcr do
     }.to_json
   end
 
-  def student_loan_params
+  def irregular_income_params
     { "payments" =>
         [{ "income_type" => "student_loan",
            "frequency" => "annual",
-           "amount" => 100.0 }] }.to_json
+           "amount" => 100.0 },
+         { "income_type" => "unspecified_source_income",
+           "frequency" => "quarterly",
+           "amount" => 303 }] }.to_json
   end
 
   def expected_remarks
@@ -494,7 +497,7 @@ RSpec.describe "Full V5 passported spec", :vcr do
 
   def expected_gross_income
     {
-      total_gross_income: 252.31333333333333,
+      total_gross_income: 353.31333333333333,
       proceeding_types: [
         { ccms_code: "DA004", client_involvement_type: "A", upper_threshold: 999_999_999_999.0, lower_threshold: 0.0, result: "eligible" },
         { ccms_code: "DA020", client_involvement_type: "A", upper_threshold: 999_999_999_999.0, lower_threshold: 0.0, result: "eligible" },
@@ -512,7 +515,7 @@ RSpec.describe "Full V5 passported spec", :vcr do
       net_housing_costs: 23.55,
       maintenance_allowance: 4.33,
       total_outgoings_and_allowances: 375.25,
-      total_disposable_income: -122.93666666666667,
+      total_disposable_income: -21.936666666666667,
       employment_income: { gross_income: 0.0, benefits_in_kind: 0.0, tax: 0.0, national_insurance: 0.0, fixed_employment_deduction: 0.0, net_employment_income: 0.0 },
       income_contribution: 0.0,
       proceeding_types: [{ ccms_code: "DA004", client_involvement_type: "A", upper_threshold: 999_999_999_999.0, lower_threshold: 315.0, result: "eligible" },

--- a/spec/requests/irregular_incomes_controller_spec.rb
+++ b/spec/requests/irregular_incomes_controller_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe IrregularIncomesController, type: :request do
         expect(parsed_response[:success]).to eq true
         expect(parsed_response[:errors]).to be_empty
       end
+
+      context "unspecified source income" do
+        let(:params) do
+          {
+            payments: [
+              {
+                income_type: "unspecified_source_income",
+                frequency: "quarterly",
+                amount: 123_456.78,
+              },
+            ],
+          }
+        end
+
+        it "creates the required number of IrregularIncomePayment records" do
+          expect { post_payload }.to change(IrregularIncomePayment, :count).by(1)
+          payments = gross_income_summary.irregular_income_payments
+          expect(payments[0].income_type).to eq CFEConstants::UNSPECIFIED_SOURCE_INCOME
+          expect(payments[0].frequency).to eq CFEConstants::QUARTERLY_FREQUENCY
+          expect(payments[0].amount).to eq 123_456.78
+        end
+      end
     end
 
     context "invalid_payload" do
@@ -75,7 +97,7 @@ RSpec.describe IrregularIncomesController, type: :request do
 
         it "contains an error message" do
           post_payload
-          expect(parsed_response).to eq({ success: false, errors: ["The property '#/payments/0/income_type' value \"imagined_type\" did not match one of the following values: student_loan in schema file://public/schemas/irregular_incomes.json"] })
+          expect(parsed_response).to eq({ success: false, errors: ["The property '#/payments/0/income_type' value \"imagined_type\" did not match one of the following values: student_loan, unspecified_source_income in schema file://public/schemas/irregular_incomes.json"] })
         end
 
         it "does not create irregular income payments record" do

--- a/spec/services/assessors/gross_income_assessor_spec.rb
+++ b/spec/services/assessors/gross_income_assessor_spec.rb
@@ -11,7 +11,7 @@ module Assessors
       context "gross income has been summarised" do
         context "monthly income below upper threshold" do
           it "is eligible" do
-            set_gross_income_values gross_income_summary, 1_023, 0.0, 45.3, 2_567
+            set_gross_income_values gross_income_summary, 1_023, 0.0, 0.0, 45.3, 2_567
             assessor
             expect(gross_income_summary.summarized_assessment_result).to eq :eligible
           end
@@ -19,7 +19,7 @@ module Assessors
 
         context "monthly income equals upper threshold" do
           it "is not eligible" do
-            set_gross_income_values gross_income_summary, 2_000, 0.0, 567.00, 2_567.00
+            set_gross_income_values gross_income_summary, 2_000, 0.0, 0.0, 567.00, 2_567.00
             assessor
             expect(gross_income_summary.summarized_assessment_result).to eq :ineligible
           end
@@ -27,17 +27,17 @@ module Assessors
 
         context "monthly income above upper threshold" do
           it "is not eligible" do
-            set_gross_income_values gross_income_summary, 2_100.0, 0.0, 500.2, 2_567
+            set_gross_income_values gross_income_summary, 2_100.0, 0.0, 0.0, 500.2, 2_567
             assessor
             expect(gross_income_summary.summarized_assessment_result).to eq :ineligible
           end
         end
 
-        def set_gross_income_values(record, other_income, monthly_student_loan, state_benefits, threshold)
+        def set_gross_income_values(record, other_income, monthly_student_loan, monthly_unspecified_source_income, state_benefits, threshold)
           record.update!(monthly_other_income: other_income,
                          monthly_student_loan:,
                          monthly_state_benefits: state_benefits,
-                         total_gross_income: other_income + state_benefits + monthly_student_loan,
+                         total_gross_income: other_income + state_benefits + monthly_student_loan + monthly_unspecified_source_income,
                          upper_threshold: threshold,
                          assessment_result: "summarised")
           create :gross_income_eligibility, gross_income_summary: record, upper_threshold: threshold

--- a/spec/services/collators/regular_income_collator_spec.rb
+++ b/spec/services/collators/regular_income_collator_spec.rb
@@ -206,6 +206,7 @@ RSpec.describe Collators::RegularIncomeCollator do
       before do
         assessment.gross_income_summary.update!(
           student_loan: 111.11,
+          unspecified_source_income: 444.44,
           benefits_cash: 222.22,
           benefits_all_sources: 222.22,
           total_gross_income: 333.33,
@@ -215,6 +216,7 @@ RSpec.describe Collators::RegularIncomeCollator do
       it "has expected values prior to regular income collation" do
         expect(gross_income_summary).to have_attributes(
           student_loan: 111.11,
+          unspecified_source_income: 444.44,
           benefits_bank: 0.0,
           benefits_cash: 222.22,
           benefits_all_sources: 222.22,

--- a/spec/services/decorators/v5/gross_income_decorator_spec.rb
+++ b/spec/services/decorators/v5/gross_income_decorator_spec.rb
@@ -9,6 +9,7 @@ module Decorators
         create :gross_income_summary,
                assessment:,
                monthly_student_loan: 250,
+               monthly_unspecified_source_income: 423.35,
                benefits_all_sources: 1_322.6,
                benefits_bank: 1_322.6,
                maintenance_in_all_sources: 350,
@@ -91,6 +92,7 @@ module Decorators
             monthly_equivalents:
               {
                 student_loan: 250.0,
+                unspecified_source_income: 423.35,
               },
           },
           state_benefits: {

--- a/spec/services/decorators/v5/gross_income_summary_decorator_spec.rb
+++ b/spec/services/decorators/v5/gross_income_summary_decorator_spec.rb
@@ -50,8 +50,8 @@ module Decorators
               expect(decorator[:state_benefits][:monthly_equivalents].keys).to match expected_keys
             end
 
-            it "returns expected keys for student_loan" do
-              expected_keys = %i[student_loan]
+            it "returns expected keys for irregular payments" do
+              expected_keys = %i[student_loan unspecified_source_income]
               expect(decorator[:irregular_income][:monthly_equivalents].keys).to match expected_keys
             end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-400)

We want to capture income that is from an unspecified source, expressed by the user as a single total figure received over the past 3 months. By 'unspecified source' we mean income that doesn't fall under any of the named types of regular or irregular payments that CFE accepts, with no requirement on the user to describe the source in any way.

So this PR adds 'unspecified_source_income' as a valid irregular type, and 'quarterly' as a valid income frequency, to the irregular payments model/endpoint.

Also, because prior to this there was only one irregular payment type - student loans - there was a bit of logic that assumed _all_ irregular payments were student loans, an assumption that started to break with the new type. So I unpicked that logic.
